### PR TITLE
Topic comm

### DIFF
--- a/algorithm/CMakeLists.txt
+++ b/algorithm/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(algorithm)
+
+find_package(catkin REQUIRED COMPONENTS
+  #message_generations
+  rospy
+  std_msgs
+)
+
+catkin_package(
+ CATKIN_DEPENDS message_generations rospy std_msgs
+)
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/algorithm/package.xml
+++ b/algorithm/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>algorithm</name>
+  <version>0.1.0</version>
+  <description>The sensor_algorithm package</description>
+  <maintainer email="pi@todo.todo">pi</maintainer>
+  <license>BSD</license>
+  
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>message_generations</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_export_depend>message_generations</build_export_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <exec_depend>message_generations</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  
+
+</package>

--- a/algorithm/src/msg_sub
+++ b/algorithm/src/msg_sub
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+import rospy
+from common_msgs.msg import Msg
+from common_msgs.srv import Srv, SrvResponse
+
+
+def srv_callback(req) :
+    rep = SrvResponse(result=req.type1 and req.type2)
+    if rep.result == False:
+        print("-------10 second pass---------")
+    elif rep.result == True:
+        print("------Reset count--------")
+    return rep
+
+
+def callback(msg):
+    print("subscribe", msg.number)
+    calb1 = msg.number.data * msg.rotation.position.x
+    calb2 = msg.rotation.orientation.x * msg.rotation.position.y
+    print(calb1)
+    print(calb2)
+    print("------")
+
+
+
+
+rospy.init_node('msg_pub')
+sub = rospy.Subscriber('DateTime_msg', Msg, callback)
+srv = rospy.Service('srv_requester', Srv, srv_callback)
+rospy.spin()

--- a/common_msgs/CMakeLists.txt
+++ b/common_msgs/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(common_msgs)
+
+find_package(catkin REQUIRED COMPONENTS
+    rospy
+    std_msgs
+    geometry_msgs
+    message_generation
+)
+
+
+add_message_files(
+  FILES
+  Msg.msg
+)    
+
+add_service_files(
+  FILES
+  Srv.srv
+)
+
+generate_messages(
+  DEPENDENCIES
+  geometry_msgs
+  std_msgs
+)
+    
+
+catkin_package(
+  CATKIN_DEPENDS geometry_msgs rospy std_msgs
+)

--- a/common_msgs/msg/Msg.msg
+++ b/common_msgs/msg/Msg.msg
@@ -1,0 +1,2 @@
+std_msgs/Float64 number
+geometry_msgs/Pose rotation

--- a/common_msgs/package.xml
+++ b/common_msgs/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>common_msgs</name>
+  <version>0.1.0</version>
+  <description>The service_custom package</description>
+  <maintainer email="ian@email.com">ian</maintainer>
+  <license>BSD</license>
+
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+  <build_export_depend>rospy</build_export_depend>
+
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+
+</package>

--- a/common_msgs/srv/Srv.srv
+++ b/common_msgs/srv/Srv.srv
@@ -1,0 +1,4 @@
+bool type1
+bool type2
+---
+bool result

--- a/sensor/CMakeLists.txt
+++ b/sensor/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(sensor)
+
+
+find_package(catkin REQUIRED COMPONENTS
+  #message_generations
+  rospy
+  std_msgs
+)
+
+catkin_package(
+  CATKIN_DEPENDS rospy std_msgs
+)
+
+
+
+
+
+
+
+
+

--- a/sensor/package.xml
+++ b/sensor/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>sensor</name>
+  <version>0.1.0</version>
+  <description>The sensor_algorithm package</description>
+  <maintainer email="pi@todo.todo">pi</maintainer>
+  <license>BSD</license>
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>message_generations</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <build_export_depend>message_generations</build_export_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+
+  <exec_depend>message_generations</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <export>
+    
+  </export>
+</package>

--- a/sensor/src/msg_pub.py
+++ b/sensor/src/msg_pub.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+import rospy
+from common_msgs.msg import Msg
+from common_msgs.srv import Srv, SrvRequest
+
+
+rospy.init_node('msg_pub', anonymous=True)
+requester = rospy.ServiceProxy('srv_requester', Srv)
+count = 0
+msg = Msg()
+
+pub = rospy.Publisher("DateTime_msg", Msg, queue_size = 1)
+rate = rospy.Rate(1)
+msg.number.data = 0
+msg.rotation.orientation.x = 0.0
+msg.rotation.orientation.y = 0.0
+msg.rotation.orientation.z = 0.0
+msg.rotation.position.x = 0.0
+msg.rotation.position.y = 0.0
+msg.rotation.position.z = 0.0
+
+while not rospy.is_shutdown():
+    count += 1
+    msg.number.data += 1
+    msg.rotation.orientation.x += 1
+    msg.rotation.orientation.y += 1
+    msg.rotation.orientation.z += 1
+    msg.rotation.orientation.w += 1
+    msg.rotation.position.x += 1
+    msg.rotation.position.y += 2
+    msg.rotation.position.z += 3
+    pub.publish(msg)
+    if count == 10:
+        req = SrvRequest(type1 = True, type2 = False)
+        res = requester(req)
+        print "Requested data : ", req.type1, req.type2
+        print "Responsed data : ", res.result
+    elif count == 20:
+        req = SrvRequest(type1 = True, type2 = True)
+        res = requester(req)
+        print "Requested data : ", req.type1, req.type2
+        print "Responsed data : ", res.result
+        count = 0
+        
+    print(msg.number)
+    print(msg.rotation)
+    rate.sleep()
+
+
+
+    
+    


### PR DESCRIPTION
common_msgs 패키지는 sensor, algorithm 에서 공통으로 참조하는 msg, srv 등을 주기적으로 보낼 수 있도록 구성하였다.
common_msgs/CMakeLists.txt에는 메시지 추가 파일, 서비스 추가 파일 등을 참조할 수 있게 구성하였다.
sensor/msg_pub.py 에서는 센서 정보를 계속 count 하게 구성하였다.
sensor/CMakeLists.txt 에서는 common_msgs 에서 만들었던 공통을 참고하여 사용하도록 구성하였다.
algorithm/msg_sub.py 에서는 count한 센서 정보를 처리해주도록 구성하였다.
algorithm/CMakeLists.txt 에서는 common_msgs 에서 만들었던 공통을 참조할 수 있도록 구성하였다.


